### PR TITLE
add: user's favorites banks in the table

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -44,7 +44,6 @@ const AppRouter = () => {
         element={
           <FavoritesScreen
             userData={userData}
-            addToFavorites={addToFavorites}
             removeFromFavorites={removeFromFavorites}
           />
         }

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -6,6 +6,7 @@ import FavoritesScreen from './screens/FavoritesScreen/FavoritesScreen';
 import BankDetailsScreen from './screens/BankDetailsScreen/BankDetailsScreen';
 import filter from 'lodash/filter';
 import get from 'lodash/get';
+import { message } from 'antd';
 
 const AppRouter = () => {
   const [userData, setUserData] = useState({
@@ -14,6 +15,7 @@ const AppRouter = () => {
 
   const addToFavorites = (bankObj) => {
     setUserData({ favorites: [...get(userData, 'favorites'), bankObj] });
+    message.success('Bank added to favorites.');
   };
 
   const removeFromFavorites = (ifsc) => {
@@ -24,6 +26,7 @@ const AppRouter = () => {
     setUserData({
       favorites: newData,
     });
+    message.success('Bank removed from favorites.');
   };
 
   return (

--- a/src/constants/table/allbanksColumn.js
+++ b/src/constants/table/allbanksColumn.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import { HeartOutlined, HeartFilled } from '@ant-design/icons';
 import { find, includes } from 'lodash';
+import { Popconfirm, message } from 'antd';
 
 export const allbanksColumn = ({
   removeFromFavorites,
@@ -38,9 +39,15 @@ export const allbanksColumn = ({
     render: (record) => {
       if (find(get(userData, 'favorites'), record)) {
         return (
-          <HeartFilled
-            onClick={() => removeFromFavorites(get(record, 'ifsc'))}
-          />
+          <Popconfirm
+            title="Are you sure to remove the bank from favorites?"
+            onConfirm={() => removeFromFavorites(get(record, 'ifsc'))}
+            onCancel={() => null}
+            okText="Yes"
+            cancelText="No"
+          >
+            <HeartFilled />
+          </Popconfirm>
         );
       } else {
         return <HeartOutlined onClick={() => addToFavorites(record)} />;

--- a/src/screens/FavoritesScreen/FavoritesScreen.js
+++ b/src/screens/FavoritesScreen/FavoritesScreen.js
@@ -1,5 +1,22 @@
-const FavoritesScreen = ({ userData, setUserData }) => {
-  return <div>Favorites Screen</div>;
-};
+import { Col, Row, Select, Space, Spin, Table } from 'antd';
+import { allbanksColumn } from '../../constants/table/allbanksColumn';
+import get from 'lodash/get';
+import { useState } from 'react';
 
+const FavoritesScreen = ({ userData, removeFromFavorites }) => {
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Spin spinning={loading}>
+      <div className="screen-title">Favorites</div>
+      <Table
+        columns={allbanksColumn({
+          removeFromFavorites,
+          userData,
+        })}
+        dataSource={get(userData, 'favorites')}
+      />
+    </Spin>
+  );
+};
 export default FavoritesScreen;


### PR DESCRIPTION
This PR contains design and development code of Favorites screen.

Following features are implemented in the Favorites screen:
1) Fetching the banks marked as favorites by the user in the table.
2) Feature to remove a bank from favorites.


Following is the preview of the Favorites screen

![image](https://user-images.githubusercontent.com/68511458/147383885-6f59d438-28d9-4391-aa6f-fd43e897ef7d.png)
